### PR TITLE
Drop some sudo calls

### DIFF
--- a/modules/environment.sh
+++ b/modules/environment.sh
@@ -18,7 +18,7 @@ setup_environment_file ()
 
 setup_environment ()
 {
-    sudo echo "Requesting sudo permissions for $USER"
+    echo "Requesting sudo permissions for $USER"
 
     sudo updatedb
 

--- a/scripts/ntp.sh
+++ b/scripts/ntp.sh
@@ -67,7 +67,7 @@ ntp_install ()
 
 ntp_status ()
 {
-    local status=$(sudo pgrep -x ntpd)
+    local status=$(pgrep -x ntpd)
 
     if [[ -z "$status" ]]; then
         STATUS_NTP="Off"

--- a/scripts/postgresql.sh
+++ b/scripts/postgresql.sh
@@ -50,7 +50,7 @@ pgsql_install ()
 
 pgsql_status ()
 {
-    local status=$(sudo pgrep -x postgres)
+    local status=$(pgrep -x postgres)
 
     if [[ -z "$status" ]]; then
         STATUS_PGSQL="Off"

--- a/scripts/redis.sh
+++ b/scripts/redis.sh
@@ -62,7 +62,7 @@ redis_install ()
 
 redis_status ()
 {
-    local status=$(sudo pgrep -x redis-server)
+    local status=$(pgrep -x redis-server)
 
     if [[ -z "$status" ]]; then
         STATUS_REDIS="Off"


### PR DESCRIPTION
Fixes #25

`pgrep -x` does not require root privileges. Exiting a log view after sudo timeout should not cause a password prompt again.

Also removed one superfluous sudo call in `modules/environment.sh` which causes a prompt before the message that sudo is being called is shown.