### PR TITLE
core: Restart services after update

### DIFF
--- a/actions/core/update.sh
+++ b/actions/core/update.sh
@@ -22,14 +22,25 @@ core_update ()
         read -p "An update is available for ARK Core, do you want to install it? [Y/n] : " choice
 
         if [[ -z "$choice" || "$choice" =~ ^(yes|y|Y) ]]; then
-            forger_stop
+            local relay_on=$STATUS_RELAY
+            local forger_on=$STATUS_FORGER
+
             relay_stop
+            forger_stop
 
             heading "Starting Update..."
             git reset --hard | tee -a "$commander_log"
             git pull | tee -a "$commander_log"
-            success "Update OK!"
 
+            if [[ "$relay_on" = "On" ]]; then
+                relay_start
+            fi
+
+            if [[ "$forger_on" = "On" ]]; then
+                forger_start
+            fi
+
+            success "Update OK!"
             STATUS_CORE_UPDATE="No"
         fi
     fi


### PR DESCRIPTION
Fixes #29 

Remember the status of the forger/relay prior updating and restart them if necessary once finished.

Test plan:
Started the relay, performed a core update and the relay was restarted.
Didn't test the forger, but should behave the same in theory.