### PR TITLE
Allow commander to launch without sudo

### DIFF
--- a/actions/miscellaneous/updates.sh
+++ b/actions/miscellaneous/updates.sh
@@ -6,7 +6,6 @@ miscellaneous_install_updates ()
 
     heading "Checking for system updates..."
 
-    sudo apt-get update >> "$commander_log" 2>&1
     available_updates=$(/usr/lib/update-notifier/apt-check 2>&1 | cut -d ";" -f 1)
     security_updates=$(/usr/lib/update-notifier/apt-check 2>&1 | cut -d ";" -f 2)
 

--- a/modules/environment.sh
+++ b/modules/environment.sh
@@ -20,10 +20,6 @@ setup_environment_file ()
 
 setup_environment ()
 {
-    echo "Requesting sudo permissions for $USER"
-
-    sudo updatedb
-
     set_locale
 
     if [[ ! -f "$commander_config" ]]; then


### PR DESCRIPTION
Allows the Commander to launch without a `sudo` prompt.

`sudo updatedb` is not needed according to #33 and `sudo apt-get update` is not necessary since `/usr/lib/update-notifier/apt-check` is the preferred way of checking for updates.