### PR TITLE
Add pm2status helper, check status before trying to delete relay/forger

### DIFF
--- a/actions/apps/explorer.sh
+++ b/actions/apps/explorer.sh
@@ -116,7 +116,7 @@ explorer_logs ()
 
 explorer_status ()
 {
-    local status=$(pm2 status 2>/dev/null | fgrep "ark-explorer" | awk '{print $10}')
+    local status=$(pm2status "ark-explorer" | awk '{print $10}')
 
     if [[ "$status" == "online" ]]; then
         STATUS_EXPLORER="On"

--- a/actions/apps/forger.sh
+++ b/actions/apps/forger.sh
@@ -49,13 +49,16 @@ forger_delete ()
 {
     ascii
 
-    heading "Deleting Forger..."
+    local delete_forger=$(pm2status "ark-core-forger" | awk '{print $2}')
+    if [[ -n $delete_forger ]]; then
+        heading "Deleting Forger..."
 
-    pm2 delete ark-core-forger >> "$commander_log" 2>&1
+        pm2 delete ark-core-forger >> "$commander_log" 2>&1
 
-    forger_status
+        forger_status
 
-    success "Deleted Forger!"
+        success "Deleted Forger!"
+    fi
 }
 
 forger_logs ()
@@ -69,7 +72,7 @@ forger_logs ()
 
 forger_status ()
 {
-    local status=$(pm2 status 2>/dev/null | fgrep "ark-core-forger" | awk '{print $10}')
+    local status=$(pm2status "ark-core-forger" | awk '{print $10}')
 
     if [[ "$status" == "online" ]]; then
         STATUS_FORGER="On"

--- a/actions/apps/relay.sh
+++ b/actions/apps/relay.sh
@@ -43,13 +43,16 @@ relay_delete ()
 {
     ascii
 
-    heading "Deleting Relay..."
+    local delete_forger=$(pm2status 'ark-core-relay' | awk '{print $2}')
+    if [[ -n $delete_forger ]]; then
+        heading "Deleting Relay..."
 
-    pm2 delete ark-core-relay >> "$commander_log" 2>&1
+        pm2 delete ark-core-relay >> "$commander_log" 2>&1
 
-    relay_status
+        relay_status
 
-    success "Deleted Relay!"
+        success "Deleted Relay!"
+    fi
 }
 
 relay_logs ()
@@ -63,7 +66,7 @@ relay_logs ()
 
 relay_status ()
 {
-    local status=$(pm2 status 2>/dev/null | fgrep "ark-core-relay" | awk '{print $10}')
+    local status=$(pm2status "ark-core-relay" | awk '{print $10}')
 
     if [[ "$status" == "online" ]]; then
         STATUS_RELAY="On"

--- a/commander.sh
+++ b/commander.sh
@@ -16,6 +16,7 @@ commander_config="${HOME}/.commander"
 . "${commander_dir}/helpers/typography.sh"
 . "${commander_dir}/helpers/continue.sh"
 . "${commander_dir}/helpers/reboot.sh"
+. "${commander_dir}/helpers/pm2status.sh"
 . "${commander_dir}/helpers/errors.sh"
 . "${commander_dir}/helpers/core.sh"
 

--- a/helpers/pm2status.sh
+++ b/helpers/pm2status.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+pm2status ()
+{
+   echo $(pm2 status | grep -E "(^| )$1( |$)")
+}


### PR DESCRIPTION
Partial fix for #21.

The errors
`==> Deleting Forger... [PM2][ERROR] Process ark-core-forger not found`
and
` ==> Deleting Relay... [PM2][ERROR] Process ark-core-relay not found`

are prevented by checking the status of the process before calling delete.


The added `pm2status` helper also fixes a potential issue, where the name of a process overlaps with the name of another process.

Scenario: status of `ark-core` is wanted, only `ark-core-relay` is active.
The previous grep call would have erroneously returned the status of ark-core-relay.

Will take a look at the remaining errors in the issue later.
