### PR TITLE
Fix error during uninstall

### DIFF
--- a/actions/core/uninstall.sh
+++ b/actions/core/uninstall.sh
@@ -14,6 +14,9 @@ core_uninstall ()
 
     database_drop_user
 
+    # Ensure we are not in a directory we are going to delete
+    cd "$commander_dir"
+
     sudo rm -rf "$CORE_DIR"
     sudo rm -rf "$CORE_DATA"
 


### PR DESCRIPTION
Fixes #21 

The `Error: ENOENT: no such file or directory, uv_cwd` was caused by calling `rm -rf` on the current working directory which at this stage points to `$CORE_DIR`.

Fixed by moving out of the directory before calling `rm -rf`.
