### PR TITLE
Core uninstall

### DIFF
--- a/menus/core/args.sh
+++ b/menus/core/args.sh
@@ -19,7 +19,7 @@ menu_manage_core_parse_args ()
 
             press_to_continue
 
-            menu_manage_core
+            menu_main
         ;;
         c|C)
             core_configure


### PR DESCRIPTION
After core uninstall I'm still in the core menu and I can again select Update/Uninstall even though the core is not installed.

<img width="653" alt="screen shot 2018-06-19 at 11 23 04" src="https://user-images.githubusercontent.com/3462869/41585901-0a227038-73b4-11e8-9847-3d2780ace8dd.png">
<img width="864" alt="screen shot 2018-06-19 at 11 23 26" src="https://user-images.githubusercontent.com/3462869/41585920-110700d0-73b4-11e8-9469-e60a6ab6c302.png">

I believe you should go to the main menu after core uninstall.