### PR TITLE
Adds error handling to explorer installation

### DIFF
--- a/actions/apps/explorer.sh
+++ b/actions/apps/explorer.sh
@@ -15,7 +15,7 @@ explorer_install ()
     info "Installing dependencies..."
     yarn install | tee -a "$commander_log"
 
-    check=${PIPESTATUS[0]}
+    local check=${PIPESTATUS[0]}
 
     if [ "$check" -eq 0 ]; then
         success "Installed dependencies!"

--- a/actions/apps/explorer.sh
+++ b/actions/apps/explorer.sh
@@ -14,11 +14,27 @@ explorer_install ()
 
     info "Installing dependencies..."
     yarn install | tee -a "$commander_log"
-    success "Installed dependencies!"
+
+    check=${PIPESTATUS[0]}
+
+    if [ "$check" -eq 0 ]; then
+        success "Installed dependencies!"
+    else
+        error "Could not install dependencies!"
+        return
+    fi
 
     info "Building..."
     yarn build:"$CORE_NETWORK" | tee -a "$commander_log"
-    success "Building!"
+
+    check=${PIPESTATUS[0]}
+
+    if [ "$check" -eq 0 ]; then
+        success "Built succesfully!"
+    else
+        error "Could not build!"
+        return
+    fi
 
     success "Installed ARK Explorer!"
 }


### PR DESCRIPTION
## Proposed changes

The explorer installation does always show a positive message, even when the installation/building of the explorer fails - see #49. This PR adds checks against the return code of the `yarn` commands and presents the user with a corresponding message.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/docs/contributing) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
