### PR TITLE
Use pm2 describe rather than pm2 status to check status of relay/forger/explorer

### DIFF
--- a/actions/apps/explorer.sh
+++ b/actions/apps/explorer.sh
@@ -132,7 +132,7 @@ explorer_logs ()
 
 explorer_status ()
 {
-    local status=$(pm2status "ark-explorer" | awk '{print $10}')
+    local status=$(pm2status "ark-explorer" | awk '{print $13}')
 
     if [[ "$status" == "online" ]]; then
         STATUS_EXPLORER="On"

--- a/actions/apps/forger.sh
+++ b/actions/apps/forger.sh
@@ -72,7 +72,7 @@ forger_logs ()
 
 forger_status ()
 {
-    local status=$(pm2status "ark-core-forger" | awk '{print $10}')
+    local status=$(pm2status "ark-core-forger" | awk '{print $13}')
 
     if [[ "$status" == "online" ]]; then
         STATUS_FORGER="On"

--- a/actions/apps/relay.sh
+++ b/actions/apps/relay.sh
@@ -66,7 +66,7 @@ relay_logs ()
 
 relay_status ()
 {
-    local status=$(pm2status "ark-core-relay" | awk '{print $10}')
+    local status=$(pm2status "ark-core-relay" | awk '{print $13}')
 
     if [[ "$status" == "online" ]]; then
         STATUS_RELAY="On"

--- a/helpers/pm2status.sh
+++ b/helpers/pm2status.sh
@@ -2,5 +2,5 @@
 
 pm2status ()
 {
-   echo $(pm2 status | grep -E "(^| )$1( |$)")
+   echo $(pm2 describe $1 2>/dev/null)
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
This changes the pm2status function to use `pm2 describe` rather than `pm2 status`, as newer versions of pm2 add an extra `version` column in `pm2 status` which breaks the ability to check if the relay/forger/explorer are online or not. Scripts that rely on pm2status have also been updated to work with the output of `pm2 describe` by changing `$10` to `$13`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

The alternative approach would be to continue using `pm2 status` but modifying relay.sh, forger.sh and relay.sh to use the 6th column rather than the 5th, i.e. `$12` instead of `$10` to accommodate the new column, but this would break for users still using the old version of pm2. This approach maintains compatibility across both versions.