### PR TITLE
Use ecosystem.config.js

### DIFF
--- a/actions/apps/explorer.sh
+++ b/actions/apps/explorer.sh
@@ -94,7 +94,7 @@ explorer_start ()
 
     heading "Starting Explorer..."
 
-    EXPLORER_HOST="0.0.0.0" EXPLORER_PORT=4200 pm2 start "$EXPLORER_DIR/express-server.js" --name ark-explorer >> "$commander_log" 2>&1
+    pm2 start $commander_ecosystem --only ark-explorer >> "$commander_log" 2>&1
 
     success "Started Explorer!"
 }
@@ -105,7 +105,7 @@ explorer_restart ()
 
     heading "Restarting Explorer..."
 
-    pm2 restart ark-explorer >> "$commander_log" 2>&1
+    pm2 restart $commander_ecosystem --only ark-explorer >> "$commander_log" 2>&1
 
     success "Restarted Explorer!"
 }
@@ -116,7 +116,7 @@ explorer_stop ()
 
     heading "Stopping Explorer..."
 
-    pm2 stop ark-explorer >> "$commander_log" 2>&1
+    pm2 stop $commander_ecosystem --only ark-explorer >> "$commander_log" 2>&1
 
     success "Stopped Explorer!"
 }

--- a/actions/apps/forger.sh
+++ b/actions/apps/forger.sh
@@ -25,7 +25,7 @@ forger_restart ()
 
     heading "Restarting Forger..."
 
-    pm2 restart ark-core-forger >> "$commander_log" 2>&1
+    pm2 restart $commander_ecosystem --only ark-core-forger >> "$commander_log" 2>&1
 
     forger_status
 
@@ -38,7 +38,7 @@ forger_stop ()
 
     heading "Stopping Forger..."
 
-    pm2 stop ark-core-forger >> "$commander_log" 2>&1
+    pm2 stop $commander_ecosystem --only ark-core-forger >> "$commander_log" 2>&1
 
     forger_status
 
@@ -53,7 +53,7 @@ forger_delete ()
     if [[ -n $delete_forger ]]; then
         heading "Deleting Forger..."
 
-        pm2 delete ark-core-forger >> "$commander_log" 2>&1
+        pm2 delete $commander_ecosystem --only ark-core-forger >> "$commander_log" 2>&1
 
         forger_status
 
@@ -144,10 +144,10 @@ __forger_start_with_bip38 ()
 
     read -sp "Please enter your bip38 password: " password
 
-    pm2 start "$CORE_DIR/packages/core/bin/ark" --name ark-core-forger -- forger --data "$CORE_DATA" --config "$CORE_CONFIG" --token "$CORE_TOKEN" --network "$CORE_NETWORK" --bip38 "$bip38" --password "$password" >> "$commander_log" 2>&1
+    pm2 start $commander_ecosystem --only ark-core-forger -- --bip38 "$bip38" --password "$password" >> "$commander_log" 2>&1
 }
 
 __forger_start_without_bip38 ()
 {
-    pm2 start "$CORE_DIR/packages/core/bin/ark" --name ark-core-forger -- forger --data "$CORE_DATA" --config "$CORE_CONFIG" --token "$CORE_TOKEN" --network "$CORE_NETWORK" >> "$commander_log" 2>&1
+    pm2 start $commander_ecosystem --only ark-core-forger >> "$commander_log" 2>&1
 }

--- a/actions/apps/relay.sh
+++ b/actions/apps/relay.sh
@@ -6,7 +6,7 @@ relay_start ()
 
     heading "Starting Relay..."
 
-    pm2 start "$CORE_DIR/packages/core/bin/ark" --name ark-core-relay -- relay --data "$CORE_DATA" --config "$CORE_CONFIG" --token "$CORE_TOKEN" --network "$CORE_NETWORK" >> "$commander_log" 2>&1
+    pm2 start $commander_ecosystem --only ark-core-relay >> "$commander_log" 2>&1
 
     relay_status
 
@@ -19,7 +19,7 @@ relay_restart ()
 
     heading "Restarting Relay..."
 
-    pm2 restart ark-core-relay >> "$commander_log" 2>&1
+    pm2 restart $commander_ecosystem --only ark-core-relay >> "$commander_log" 2>&1
 
     relay_status
 
@@ -32,7 +32,7 @@ relay_stop ()
 
     heading "Stopping Relay..."
 
-    pm2 stop ark-core-relay >> "$commander_log" 2>&1
+    pm2 stop $commander_ecosystem --only ark-core-relay >> "$commander_log" 2>&1
 
     relay_status
 
@@ -47,7 +47,7 @@ relay_delete ()
     if [[ -n $delete_forger ]]; then
         heading "Deleting Relay..."
 
-        pm2 delete ark-core-relay >> "$commander_log" 2>&1
+        pm2 delete $commander_ecosystem --only ark-core-relay >> "$commander_log" 2>&1
 
         relay_status
 

--- a/commander.sh
+++ b/commander.sh
@@ -7,6 +7,7 @@
 commander=$(basename "$0")
 commander_dir="$(cd "$(dirname "$0")" && pwd)"
 commander_log="${commander_dir}/logs/commander.log"
+commander_ecosystem="${commander_dir}/ecosystem.config.js"
 commander_config="${HOME}/.commander"
 
 # -------------------------

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,36 @@
+require('dotenv').config({ path: `${process.env.HOME}/.commander` })
+
+const parseArg = (key) => {
+    const index = process.argv.indexOf(key)
+    if (index !== -1) {
+        return `${key} ${process.argv[index + 1]}`
+    }
+
+    return ''
+}
+
+module.exports = {
+  apps : [{
+    name: 'ark-core-relay',
+    script: `${process.env.CORE_DIR}/packages/core/bin/ark`,
+    args: `relay --data ${process.env.CORE_DATA}
+                 --config ${process.env.CORE_CONFIG}
+                 --token ${process.env.CORE_TOKEN}
+                 --network ${process.env.CORE_NETWORK}`,
+
+    max_restarts: 5,
+    min_uptime: '5m'
+  }, {
+    name: 'ark-core-forger',
+    script: `${process.env.CORE_DIR}/packages/core/bin/ark`,
+    args: `forger --data ${process.env.CORE_DATA}
+                  --config ${process.env.CORE_CONFIG}
+                  --token ${process.env.CORE_TOKEN}
+                  --network ${process.env.CORE_NETWORK}
+                  ${parseArg('--bip38')}
+                  ${parseArg('--password')}`,
+
+    max_restarts: 5,
+    min_uptime: '5m'
+  }]
+};

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -17,7 +17,6 @@ module.exports = {
                  --config ${process.env.CORE_CONFIG}
                  --token ${process.env.CORE_TOKEN}
                  --network ${process.env.CORE_NETWORK}`,
-
     max_restarts: 5,
     min_uptime: '5m'
   }, {
@@ -29,8 +28,17 @@ module.exports = {
                   --network ${process.env.CORE_NETWORK}
                   ${parseArg('--bip38')}
                   ${parseArg('--password')}`,
-
     max_restarts: 5,
     min_uptime: '5m'
+  }, {
+    name: 'ark-explorer',
+    script: `${process.env.EXPLORER_DIR}/express-server.js`,
+    args: `--name ark-explorer`,
+    max_restarts: 5,
+    min_uptime: '5m',
+    env: {
+        EXPLORER_HOST: '0.0.0.0',
+        EXPLORER_PORT: 4200
+    }
   }]
 };

--- a/modules/dependencies.sh
+++ b/modules/dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 DEPENDENCIES_PROGRAMS=("build-essential libcairo2-dev pkg-config libtool autoconf automake python git curl libpq-dev jq")
-DEPENDENCIES_NODEJS=("pm2 lerna")
+DEPENDENCIES_NODEJS=("pm2 lerna dotenv ")
 
 apt_package_installed()
 {
@@ -54,7 +54,6 @@ install_program_dependencies ()
         success "Program dependencies Installed!"
     fi
 
-    redis_install
     pgsql_install
     ntp_install
 

--- a/modules/dependencies.sh
+++ b/modules/dependencies.sh
@@ -54,6 +54,7 @@ install_program_dependencies ()
         success "Program dependencies Installed!"
     fi
 
+    redis_install
     pgsql_install
     ntp_install
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Move the configs for relay, forger and explorer to a central ecosystem.config.js  (reference: https://pm2.io/doc/en/runtime/guide/ecosystem-file/ )

Now one can simply fire up a relay by executing `pm2 start ecosystem.config.js  --only ark-core-relay`  instead of having to replicate what commander did previously:
`    pm2 start "$CORE_DIR/packages/core/bin/ark" --name ark-core-relay -- relay --data "$CORE_DATA" --config "$CORE_CONFIG" --token "$CORE_TOKEN" --network "$CORE_NETWORK" `

The `ecosystem.config.js` leverages more options, essentially we can now prevent an endless restart loop as described here https://github.com/ArkEcosystem/core/issues/849 After 5 restarts in less than 5 minutes pm2 will stop trying. 


I added a new npm dependency `dotenv` which is used to read the `.commander` file. It is necessary to install it manually `sudo npm install -g dotenv` unless we perform dependency check in commander at every start.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
