### PR TITLE
removes double case in menu option parsing

### DIFF
--- a/menus/core/args.sh
+++ b/menus/core/args.sh
@@ -28,13 +28,6 @@ menu_manage_core_parse_args ()
 
             menu_manage_core
         ;;
-        c|C)
-            core_configure
-
-            press_to_continue
-
-            menu_manage_core
-        ;;
         l|L)
             core_configure_log_level
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

In the parsing of the ARK Core menu options the `c|C` case was present twice.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
<!--
## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
