### PR TITLE
fix: add 'apt-transport-https' to base dependencies

### DIFF
--- a/modules/dependencies.sh
+++ b/modules/dependencies.sh
@@ -24,7 +24,7 @@ install_base_dependencies ()
     heading "Installing system dependencies..."
 
     sudo apt-get update >> "$commander_log" 2>&1
-    sudo apt-get install -y git curl | tee -a "$commander_log"
+    sudo apt-get install -y git curl apt-transport-https | tee -a "$commander_log"
 
     nodejs_install
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Adds the `apt-transport-https` package so that we can fetch packages over https. 

```bash
Reading package lists...
E: The method driver /usr/lib/apt/methods/https could not be found.
E: Failed to fetch https://deb.nodesource.com/node_9.x/dists/xenial/InRelease
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation