### PR TITLE
fix: add 'press_to_continue' to main menu logs

### DIFF
--- a/menus/main/args.sh
+++ b/menus/main/args.sh
@@ -37,6 +37,8 @@ menu_main_parse_args ()
         ;;
         l|L)
             utils_log
+
+            press_to_continue
         ;;
         h|H)
             menu_main_help


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The only way to exit the logs which can be viewed through the main menu is to hit ctrl + c followed by enter. This results in `Invalid option chosen, please select a valid option and try again.` being shown in the main menu.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation