### PR TITLE
fix: add 'update-notifier' to base dependencies

### DIFF
--- a/modules/dependencies.sh
+++ b/modules/dependencies.sh
@@ -24,7 +24,7 @@ install_base_dependencies ()
     heading "Installing system dependencies..."
 
     sudo apt-get update >> "$commander_log" 2>&1
-    sudo apt-get install -y git curl apt-transport-https | tee -a "$commander_log"
+    sudo apt-get install -y git curl apt-transport-https update-notifier | tee -a "$commander_log"
 
     nodejs_install
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Adds the package `update-notifier` to the base dependencies.

```
==> There are /home/devnet/core-commander/actions/miscellaneous/updates.sh: line 9: /usr/lib/update-notifier/apt-check: No such file or directory system updates available. /home/devnet/core-commander/actions/miscellaneous/updates.sh: line 10: /usr/lib/update-notifier/apt-check: No such file or directory of them are security updates!
```

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
