### PR TITLE
refactor: only create a psql account for the system user

### DIFF
--- a/modules/database.sh
+++ b/modules/database.sh
@@ -27,11 +27,7 @@ database_create ()
     # needed to avoid "could not connect to database template1" errors
     sudo -u postgres psql -c "CREATE USER $USER WITH PASSWORD 'password' CREATEDB;" | tee -a "$commander_log"
 
-    sudo -u postgres psql -c "CREATE USER $ARK_DB_USERNAME WITH PASSWORD '$ARK_DB_PASSWORD' CREATEDB;" | tee -a "$commander_log"
-
     createdb "$ARK_DB_DATABASE" | tee -a "$commander_log"
-
-    sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE $ARK_DB_DATABASE TO $ARK_DB_USERNAME;" | tee -a "$commander_log"
 
     wait_to_continue
 

--- a/modules/environment.sh
+++ b/modules/environment.sh
@@ -11,7 +11,7 @@ setup_environment_file ()
 
         echo "ARK_DB_HOST=localhost" >> "$envFile" 2>&1
         echo "ARK_DB_PORT=5432" >> "$envFile" 2>&1
-        echo "ARK_DB_USERNAME=ark" >> "$envFile" 2>&1
+        echo "ARK_DB_USERNAME=${USER}" >> "$envFile" 2>&1
         echo "ARK_DB_PASSWORD=password" >> "$envFile" 2>&1
         echo "ARK_DB_DATABASE=ark_devnet" >> "$envFile" 2>&1
     fi


### PR DESCRIPTION
Inserts the system user into .env instead of "ark". Removes duplicate user creation and permission setup.