### PR TITLE
refactor: get state/versions only when necessary

### DIFF
--- a/actions/core/install.sh
+++ b/actions/core/install.sh
@@ -27,5 +27,7 @@ core_install ()
         ascii
 
         success "Installed Ark Core!"
+
+        core_version
     fi
 }

--- a/actions/core/uninstall.sh
+++ b/actions/core/uninstall.sh
@@ -26,4 +26,6 @@ core_uninstall ()
     success "Deleted Configuration!"
 
     success "Uninstalled Ark Core!"
+
+    core_version
 }

--- a/actions/core/update.sh
+++ b/actions/core/update.sh
@@ -55,6 +55,8 @@ core_update ()
 
             success "Update OK!"
             STATUS_CORE_UPDATE="No"
+
+            core_version
         fi
     fi
 }

--- a/actions/miscellaneous/updates.sh
+++ b/actions/miscellaneous/updates.sh
@@ -37,4 +37,6 @@ miscellaneous_install_updates ()
             press_to_continue
         fi
     fi
+
+    get_versions
 }

--- a/commander.sh
+++ b/commander.sh
@@ -117,6 +117,8 @@ main ()
 
     if [[ -d "$EXPLORER_DIR" ]]; then
         explorer_update
+    else
+        STATUS_EXPLORER_UPDATE="n/a"
     fi
 
     while true; do

--- a/menus/core/menu.sh
+++ b/menus/core/menu.sh
@@ -5,6 +5,7 @@ menu_manage_core ()
     ascii
 
     forger_status
+    relay_status
 
     text_white "    U. Update Ark Core"
     text_white "    P. Uninstall Ark Core"

--- a/modules/state.sh
+++ b/modules/state.sh
@@ -2,8 +2,6 @@
 
 refresh_state ()
 {
-    get_versions
-
     ntp_status
     pgsql_status
     relay_status

--- a/modules/versions.sh
+++ b/modules/versions.sh
@@ -2,31 +2,52 @@
 
 get_versions ()
 {
+    core_version
+    node_version
+    npm_version
+    yarn_version
+    psql_version
+}
+
+core_version ()
+{
     if [[ -d "$CORE_DIR" ]]; then
         cd "$CORE_DIR"
         VERSION_CORE=$(git rev-parse --short HEAD)
     else
         VERSION_CORE="n/a"
     fi
+}
 
+node_version ()
+{
     if [[ -x "$(command -v node)" ]]; then
         VERSION_NODE=$(node -v | sed 's/v//g')
     else
         VERSION_NODE="n/a"
     fi
+}
 
+npm_version ()
+{
     if [[ -x "$(command -v npm)" ]]; then
         VERSION_NPM=$(npm -v)
     else
         VERSION_NPM="n/a"
     fi
+}
 
+yarn_version ()
+{
     if [[ -x "$(command -v yarn)" ]]; then
         VERSION_YARN=$(yarn -v)
     else
         VERSION_YARN="n/a"
     fi
+}
 
+psql_version ()
+{
     if [[ -x "$(command -v psql)" ]]; then
         VERSION_PSQL=$(psql -V | awk '{ print $3 }')
     else


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Moves `get_versions` out of `refresh_states` and calls it only when necessary, i.e. on startup and after system or core updates, allowing the main menu to load faster, see #83 

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes