### PR TITLE
fix: correct JSON-RPC variable names

### DIFF
--- a/actions/core/configure.sh
+++ b/actions/core/configure.sh
@@ -179,8 +179,8 @@ __core_configure_environment ()
     grep -q '^ARK_GRAPHQL_HOST' "$envFile" 2>&1 || echo 'ARK_GRAPHQL_HOST=0.0.0.0' >> "$envFile" 2>&1
     grep -q '^ARK_GRAPHQL_PORT' "$envFile" 2>&1 || echo 'ARK_GRAPHQL_PORT=4005' >> "$envFile" 2>&1
 
-    grep -q '^ARK_JSONRPC_HOST' "$envFile" 2>&1 || echo 'ARK_JSONRPC_HOST=0.0.0.0' >> "$envFile" 2>&1
-    grep -q '^ARK_JSONRPC_PORT' "$envFile" 2>&1 || echo 'ARK_JSONRPC_PORT=8080' >> "$envFile" 2>&1
+    grep -q '^ARK_JSON_RPC_HOST' "$envFile" 2>&1 || echo 'ARK_JSON_RPC_HOST=0.0.0.0' >> "$envFile" 2>&1
+    grep -q '^ARK_JSON_RPC_PORT' "$envFile" 2>&1 || echo 'ARK_JSON_RPC_PORT=8080' >> "$envFile" 2>&1
 
     success "Created Environment configuration!"
 }

--- a/actions/core/configure/hosts-and-ports.sh
+++ b/actions/core/configure/hosts-and-ports.sh
@@ -74,15 +74,15 @@ core_configure_hosts_and_ports ()
     read -p "Would you like to configure the JSON-RPC API? [y/N] : " choice
 
     if [[ "$choice" =~ ^(yes|y|Y) ]]; then
-        read -p "Enter the JSON-RPC host, or press ENTER for the default [${ARK_JSONRPC_HOST}]: " inputHost
-        read -p "Enter the JSON-RPC port, or press ENTER for the default [${ARK_JSONRPC_PORT}]: " inputPort
+        read -p "Enter the JSON-RPC host, or press ENTER for the default [${ARK_JSON_RPC_HOST}]: " inputHost
+        read -p "Enter the JSON-RPC port, or press ENTER for the default [${ARK_JSON_RPC_PORT}]: " inputPort
 
         if [[ ! -z "$inputHost" ]]; then
-            sed -i -e "s/ARK_JSONRPC_HOST=$ARK_JSONRPC_HOST/ARK_JSONRPC_HOST=$inputHost/g" "$envFile"
+            sed -i -e "s/ARK_JSON_RPC_HOST=$ARK_JSON_RPC_HOST/ARK_JSON_RPC_HOST=$inputHost/g" "$envFile"
         fi
 
         if [[ ! -z "$inputPort" ]]; then
-            sed -i -e "s/ARK_JSONRPC_PORT=$ARK_JSONRPC_PORT/ARK_JSONRPC_PORT=$inputPort/g" "$envFile"
+            sed -i -e "s/ARK_JSON_RPC_PORT=$ARK_JSON_RPC_PORT/ARK_JSON_RPC_PORT=$inputPort/g" "$envFile"
         fi
     fi
 


### PR DESCRIPTION
## Proposed changes

@adrian69 noticed that the JSON-RPC variables were missing an underscore.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes