### PR TITLE
[untested] fix: use dist files instead of bin to configure secret

### DIFF
--- a/actions/apps/forger.sh
+++ b/actions/apps/forger.sh
@@ -99,7 +99,7 @@ __forger_configure_plain ()
     read -sp "Please enter your delegate secret: " inputSecret
     echo
 
-    $(node "$CORE_DIR/packages/core/bin/ark" forger-plain --config "$CORE_CONFIG" --secret "$inputSecret")
+    $(node "$CORE_DIR/packages/core/dist/index.js" forger-plain --config "$CORE_CONFIG" --secret "$inputSecret")
 
     local status=$?
 
@@ -123,7 +123,7 @@ __forger_configure_bip38 ()
 
     warning "Hang in there while we encrypt your secret..."
 
-    $(node "$CORE_DIR/packages/core/bin/ark" forger-bip38 --config "$CORE_CONFIG" --token "$CORE_TOKEN" --network "$CORE_NETWORK" --secret "$inputSecret" --password "$inputBip38")
+    $(node "$CORE_DIR/packages/core/dist/index.js" forger-bip38 --config "$CORE_CONFIG" --token "$CORE_TOKEN" --network "$CORE_NETWORK" --secret "$inputSecret" --password "$inputBip38")
 
     local status=$?
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Changing the secret causes the following error:

```
internal/modules/cjs/loader.js:583
    throw err;
    ^

Error: Cannot find module '/home/ark/ark-core/packages/core/bin/ark'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:282:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:743:3)
```

Changes are based on 762f809

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation