### PR TITLE
fix: cd to commander_dir before explorer uninstall

### DIFF
--- a/actions/apps/explorer.sh
+++ b/actions/apps/explorer.sh
@@ -47,6 +47,8 @@ explorer_uninstall ()
 
     heading "Uninstalling Ark Explorer..."
 
+    cd "$commander_dir"
+
     sudo rm -rf "$EXPLORER_DIR"
 
     success "Uninstalled Ark Explorer!"


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Fixes #106 by changing to the `commander_dir` directory before deleting the explorer directory.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation