### PR TITLE
fix: use env variables for database creation

### DIFF
--- a/modules/database.sh
+++ b/modules/database.sh
@@ -4,7 +4,7 @@ database_drop_user ()
 {
     heading "Dropping Database User..."
 
-    sudo -u postgres dropuser --if-exists "$ARK_DB_USERNAME" | tee -a "$commander_log"
+    sudo -u postgres dropuser --if-exists "${ARK_DB_USERNAME}" | tee -a "$commander_log"
 
     success "Dropped Database User!"
 }
@@ -13,7 +13,7 @@ database_destroy ()
 {
     heading "Destroying Database..."
 
-    sudo -u postgres dropdb --if-exists "$ARK_DB_DATABASE" | tee -a "$commander_log"
+    sudo -u postgres dropdb --if-exists "${ARK_DB_DATABASE}" | tee -a "$commander_log"
 
     success "Destroyed Database!"
 }
@@ -26,17 +26,17 @@ database_create ()
 
     wait_to_continue
 
-    local userExists=$(sudo -u postgres psql -c "SELECT * FROM pg_user WHERE usename = '$USER'" | grep -c "1 row")
+    local userExists=$(sudo -u postgres psql -c "SELECT * FROM pg_user WHERE username = '${ARK_DB_USERNAME}'" | grep -c "1 row")
 
     if [[ $userExists == 1 ]]; then
-        read -p "The database user ${USER} already exists, do you want to overwrite it? [y/N] : " choice
+        read -p "The database user ${ARK_DB_USERNAME} already exists, do you want to overwrite it? [y/N] : " choice
 
         if [[ "$choice" =~ ^(yes|y|Y) ]]; then
-            sudo -u postgres psql -c "DROP USER $USER" | tee -a "$commander_log"
-            sudo -u postgres psql -c "CREATE USER $USER WITH PASSWORD 'password' CREATEDB;" | tee -a "$commander_log"
+            sudo -u postgres psql -c "DROP USER ${ARK_DB_USERNAME}" | tee -a "$commander_log"
+            sudo -u postgres psql -c "CREATE USER ${ARK_DB_USERNAME} WITH PASSWORD '${ARK_DB_PASSWORD}' CREATEDB;" | tee -a "$commander_log"
         fi
     else
-        sudo -u postgres psql -c "CREATE USER $USER WITH PASSWORD 'password' CREATEDB;" | tee -a "$commander_log"
+        sudo -u postgres psql -c "CREATE USER ${ARK_DB_USERNAME} WITH PASSWORD '${ARK_DB_PASSWORD}' CREATEDB;" | tee -a "$commander_log"
     fi
 
     local databaseExists=$(psql -l | grep "${ARK_DB_DATABASE}" | wc -l)


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Fixes #108 by using the env variables `ARK_DB_USERNAME` and `ARK_DB_USERNAME` instead of `USER` and the hardcoded password. Also removes a typo (usename -> username).

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation