### PR TITLE
docs: add deprecation warning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ark Core Commander
 
+**:warning: Deprecated - Ark Core comes with a built-in CLI since v2.2.0 and provides an installation script :warning:**
+
 <p align="center">
     <img src="https://github.com/ArkEcosystem/core-commander/blob/master/banner.png" />
 </p>


### PR DESCRIPTION
## Proposed changes

Add a deprecation warning for the 2.2 release of core as it will provide it's own CLI and installation script.

## Types of changes

- [x] Docs (documentation only changes)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes